### PR TITLE
Streaming insted caching

### DIFF
--- a/lib/Common/PlayerEngine.dart
+++ b/lib/Common/PlayerEngine.dart
@@ -11,7 +11,6 @@ class PlayerEngine {
   static late List<VideoHandler> _history;
   static VideoHandler? _currentPlaying;
   static final ValueNotifier<Video?> _valueListenable = ValueNotifier(null);
-  static final _loadingStreamController = StreamController<LoadingState>();
 
 
   static void initialize() {
@@ -37,9 +36,7 @@ class PlayerEngine {
   }
 
   static Future play(VideoHandler source, {bool play = true}) async {
-    _loadingStreamController.add(LoadingState.loading);
     final futureAudioSource = source.getAudioSource();
-    futureAudioSource.then((value) =>  _loadingStreamController.add(LoadingState.loaded));
     final audioSource = await futureAudioSource;
     await PlayerEngine.player.pause();
     await PlayerEngine.player.setAudioSource(audioSource);
@@ -74,10 +71,6 @@ class PlayerEngine {
 
   static ValueNotifier<Video?> getCurrentVideoPlaying() {
     return _valueListenable;
-  }
-
-  static Stream<LoadingState> getLoadingStateStream(){
-    return _loadingStreamController.stream;
   }
 
   static void addSongToQueue(VideoHandler source) async {

--- a/lib/Common/PlayerEngine.dart
+++ b/lib/Common/PlayerEngine.dart
@@ -36,8 +36,8 @@ class PlayerEngine {
   }
 
   static Future play(VideoHandler source, {bool play = true}) async {
-    final futureAudioSource = source.getAudioSource();
-    final audioSource = await futureAudioSource;
+    final futureAudioSource = await source.getAudioSource();
+    final audioSource = AudioSource.uri(futureAudioSource);
     await PlayerEngine.player.pause();
     await PlayerEngine.player.setAudioSource(audioSource);
     _valueListenable.value = source.video;

--- a/lib/Common/Utils.dart
+++ b/lib/Common/Utils.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 class Utils {
   static String durationToText(Duration? duration) {
     if (duration == null) {
@@ -17,6 +20,19 @@ class Utils {
       if (seconds < 10) s += "0";
       s += seconds.toString();
       return s;
+    }
+  }
+
+  static String viewToString(int views, BuildContext context) {
+    const oneBilion = 1000000000;
+    const oneMilion = 1000000;
+    if(views>oneBilion) {
+      return (views/oneBilion).toStringAsFixed(1)+" "+AppLocalizations.of(context)!.billions;
+    }
+    if(views>oneMilion) {
+      return (views/oneMilion).toStringAsFixed(1)+" "+AppLocalizations.of(context)!.millions;
+    } else {
+      return views.toString();
     }
   }
 }

--- a/lib/Common/VideoHandler.dart
+++ b/lib/Common/VideoHandler.dart
@@ -4,6 +4,7 @@ import 'package:holomusic/Common/PlayerEngine.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:youtube_explode_dart/youtube_explode_dart.dart' as YtExplode;
 import 'package:just_audio/just_audio.dart';
+import 'package:http/http.dart' as http;
 
 enum LoadingState { initialized, loading, loaded }
 
@@ -11,23 +12,61 @@ enum LoadingState { initialized, loading, loaded }
 class VideoHandler {
   late YtExplode.Video video;
   late YtExplode.YoutubeExplode _yt;
-  late Future<AudioSource> _audioSourceFuture;
+  late Future<Uri> _onlineStream;
+  Future<Uri>? _offlineStream;
+  bool _offlineCompleted = false;
 
-  VideoHandler(this.video) {
+  VideoHandler(this.video, {bool preload = false}) {
     _yt = YtExplode.YoutubeExplode();
-    _audioSourceFuture = _getSongStream().then((value) {
-      final source = AudioSource.uri(value);
-      return source;
-    });
+    _onlineStream = _getOnlineStream();
+    print("Video preload " + preload.toString());
+    if (preload) {
+      _onlineStream.whenComplete(() {
+        _offlineStream = _getOfflineStream();
+        _offlineStream?.whenComplete(() => _offlineCompleted = true);
+      });
+    }
   }
 
-  Future<AudioSource> getAudioSource() {
-    return _audioSourceFuture;
+  //Call this method when you really need the track.
+  //If the track was download, it returns the offline Uri, otherwise the online Uri
+  //Obviously the behaviours of this function depends by the preload parameter of the constructor.
+  Future<Uri> getAudioSource() {
+    if (_offlineCompleted && _offlineStream != null) {
+      return _offlineStream!;
+    } else {
+      return _onlineStream;
+    }
   }
 
-  Future<Uri> _getSongStream() async {
+  Future<Uri> _getOnlineStream() async {
     var manifest = await _yt.videos.streamsClient.getManifest(video.id);
     var streamInfo = manifest.audioOnly.withHighestBitrate();
     return streamInfo.url;
+  }
+
+  Future<Uri> _getOfflineStream() async {
+    //Create directory
+    Directory tempDir = await getTemporaryDirectory();
+    var folderPath = tempDir.path +
+        Platform.pathSeparator +
+        "holomusic" +
+        Platform.pathSeparator;
+    print("Preloading");
+    await Directory(folderPath).create(recursive: true);
+    var fileName = folderPath + video.id.value + ".webm";
+    var file = File(fileName);
+    //Downloading
+    var manifest = await _yt.videos.streamsClient.getManifest(video.id);
+    var streamInfo = manifest.audioOnly.withHighestBitrate();
+    var stream = _yt.videos.streamsClient.get(streamInfo);
+    var fileStream = file.openWrite();
+    await stream.pipe(fileStream);
+    // Close the file.
+    await fileStream.flush();
+    await fileStream.close();
+    print("Preloading completed");
+
+    return file.uri;
   }
 }

--- a/lib/Common/VideoHandler.dart
+++ b/lib/Common/VideoHandler.dart
@@ -13,42 +13,21 @@ class VideoHandler {
   late YtExplode.YoutubeExplode _yt;
   late Future<AudioSource> _audioSourceFuture;
 
-
   VideoHandler(this.video) {
     _yt = YtExplode.YoutubeExplode();
-    _audioSourceFuture = _downloadSong().then((value) {
-      final source = AudioSource.uri(Uri.file(value));
+    _audioSourceFuture = _getSongStream().then((value) {
+      final source = AudioSource.uri(value);
       return source;
     });
   }
-
 
   Future<AudioSource> getAudioSource() {
     return _audioSourceFuture;
   }
 
-  Future<String> _downloadSong() async {
-    Directory tempDir = await getApplicationDocumentsDirectory();
-    var folderPath = tempDir.path + Platform.pathSeparator + "holomusic" +
-        Platform.pathSeparator;
-    await Directory(folderPath).create(recursive: true);
-    var fileName = folderPath + video.id.value + ".webm";
-    var file = File(fileName);
-    if (FileSystemEntity.typeSync(fileName) == FileSystemEntityType.notFound) {
-      var manifest = await _yt.videos.streamsClient.getManifest(video.id);
-      var streamInfo = manifest.audioOnly.withHighestBitrate();
-      var stream = _yt.videos.streamsClient.get(streamInfo);
-      print("Saved on " + fileName);
-      var fileStream = file.openWrite();
-      print("Saveing");
-      await stream.pipe(fileStream);
-      print("Saved");
-      // Close the file.
-      await fileStream.flush();
-      await fileStream.close();
-    } else {
-      print("Cache used");
-    }
-    return fileName;
+  Future<Uri> _getSongStream() async {
+    var manifest = await _yt.videos.streamsClient.getManifest(video.id);
+    var streamInfo = manifest.audioOnly.withHighestBitrate();
+    return streamInfo.url;
   }
 }

--- a/lib/Views/Player/PlayerView.dart
+++ b/lib/Views/Player/PlayerView.dart
@@ -23,15 +23,27 @@ class _PlayerViewState extends State<PlayerView> {
 
   final _titleStyle =
       const TextStyle(fontSize: 16, fontWeight: FontWeight.bold);
-  final playIcon = const Icon(
-    Icons.play_circle_fill,
-    size: 70,
-    color: Colors.black,
-  );
-  final pauseIcon = const Icon(
-    Icons.pause,
-    size: 70,
-    color: Colors.black,
+
+  final playIcon = TextButton(
+      onPressed: () => PlayerEngine.toggle(),
+      child: const Icon(
+        Icons.play_circle_fill,
+        size: 70,
+        color: Colors.black,
+      ));
+
+  final pauseIcon = TextButton(
+      onPressed: () => PlayerEngine.toggle(),
+      child: const Icon(
+        Icons.pause,
+        size: 70,
+        color: Colors.black,
+      ));
+
+  final loadingIcon = const SizedBox(
+    height: 70,
+    width: 70,
+    child: CircularProgressIndicator(),
   );
 
   @override
@@ -74,7 +86,7 @@ class _PlayerViewState extends State<PlayerView> {
                     stream: PlayerEngine.player.positionStream,
                     builder: (BuildContext context,
                         AsyncSnapshot<Duration> snapshot) {
-                      if(snapshot.hasData) {
+                      if (snapshot.hasData) {
                         return TimeSlider(
                             current: snapshot.data,
                             end: PlayerEngine.player.duration,
@@ -82,8 +94,7 @@ class _PlayerViewState extends State<PlayerView> {
                               PlayerEngine.player
                                   .seek(Duration(seconds: d.toInt()));
                             });
-                      }
-                      else {
+                      } else {
                         return const SizedBox();
                       }
                     }),
@@ -98,18 +109,28 @@ class _PlayerViewState extends State<PlayerView> {
                           size: 40,
                           color: Colors.black,
                         )),
-                    TextButton(
-                        onPressed: () => PlayerEngine.toggle(),
-                        child: StreamBuilder<PlayerState>(
-                            stream: PlayerEngine.player.playerStateStream,
-                            builder: (BuildContext context,
-                                AsyncSnapshot<PlayerState> snapshot) {
-                              if (snapshot.hasData && snapshot.data!.playing) {
-                                return pauseIcon;
-                              } else {
-                                return playIcon;
-                              }
-                            })),
+                    StreamBuilder<PlayerState>(
+                        stream: PlayerEngine.player.playerStateStream,
+                        builder: (BuildContext context,
+                            AsyncSnapshot<PlayerState> snapshot) {
+                          if (snapshot.hasData) {
+                            switch (snapshot.data!.processingState) {
+                              case ProcessingState.loading:
+                              case ProcessingState.buffering:
+                                return loadingIcon;
+                              case ProcessingState.idle:
+                              case ProcessingState.ready:
+                              case ProcessingState.completed:
+                                if (snapshot.data!.playing) {
+                                  return pauseIcon;
+                                } else {
+                                  return playIcon;
+                                }
+                            }
+                          } else {
+                            return playIcon;
+                          }
+                        }),
                     TextButton(
                         onPressed: () => PlayerEngine.playNextSong(),
                         child: const Icon(

--- a/lib/Views/Search/VideoCard.dart
+++ b/lib/Views/Search/VideoCard.dart
@@ -40,7 +40,7 @@ class VideoCard extends StatelessWidget {
                       children: [
                         Image(
                           image: NetworkImage(video.thumbnails.lowResUrl),
-                          height: 60,
+                          width: 80,
                         ),
                         Expanded(
                             child: Padding(
@@ -57,6 +57,10 @@ class VideoCard extends StatelessWidget {
                                       ),
                                       Text(
                                         Utils.durationToText(video.duration),
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                      Text(
+                                        Utils.viewToString(video.engagement.viewCount, context),
                                         overflow: TextOverflow.ellipsis,
                                       )
                                     ]))),

--- a/lib/Views/SongOptions.dart
+++ b/lib/Views/SongOptions.dart
@@ -39,7 +39,7 @@ class SongOptions extends StatelessWidget {
                     const SizedBox(height: 20),
                     TextButton(
                         onPressed: () {
-                          PlayerEngine.addSongToQueue(VideoHandler(video));
+                          PlayerEngine.addSongToQueue(VideoHandler(video,preload: true));
                           Navigator.pop(context);
                         },
                         child: Row(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,5 +5,7 @@
   "library": "Library",
   "searchASong": "Search a song",
   "addToQueue": "Add to queue",
-  "cancel": "Cancel"
+  "cancel": "Cancel",
+  "millions": "Millions",
+  "billions": "Billions"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -5,5 +5,7 @@
   "library": "Raccolta",
   "searchASong": "Cerca una canzone",
   "addToQueue": "Aggiungi in coda",
-  "cancel": "Annulla"
+  "cancel": "Annulla",
+  "millions": "Milioni",
+  "billions": "Miliardi"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
@@ -83,13 +84,13 @@ class _MyHomePageState extends State<MyHomePage> {
     ];
   }
 
-  _getBarWidget(LoadingState state) {
+  _getBarWidget(ProcessingState state) {
     final a = List<Widget>.empty(growable: true);
 
-    if (state == LoadingState.loading) {
+    if (state == ProcessingState.buffering || state == ProcessingState.loading) {
       a.add(const Flexible(child: LinearProgressIndicator()));
     }
-    if (state == LoadingState.loaded || _playBarMustBeShown) {
+    if (state == ProcessingState.ready || _playBarMustBeShown) {
       a.add(Flexible(child: PlayBar(handler: _videoHandler!)));
       _playBarMustBeShown = true;
     }
@@ -104,9 +105,9 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: pageList[_selectedNavigationBarElement],
       //bottomSheet: _videoHandler != null ? PlayBar(handler: _videoHandler!) : null,
-      bottomSheet: StreamBuilder<LoadingState>(
-          stream: PlayerEngine.getLoadingStateStream(),
-          initialData: LoadingState.initialized,
+      bottomSheet: StreamBuilder<ProcessingState>(
+          stream: PlayerEngine.player.processingStateStream,
+          initialData: ProcessingState.idle,
           builder: (context, snapshot) {
             if (snapshot.hasData) {
               final state = snapshot.data!;


### PR DESCRIPTION
This PR has 2 beautiful improvements:

- Previously the song was downloaded and the played, now it plays the song in streaming, so the user doesn't wait that the download finish to listen the music.
- SMART LOADING, when the user "add to the queue" a song, a download in background starts, and when the user play this added song, if the download is finished, the off-line song is played, otherwise will be stream the on-line version.