### PR TITLE
On track end on 1 song playlist error fix

### DIFF
--- a/lib/Common/Player/PlayerEngine.dart
+++ b/lib/Common/Player/PlayerEngine.dart
@@ -43,7 +43,7 @@ class PlayerEngine {
 
   static void onTrackEnd() async {
     if (_mainPlaylist.isNotEmpty ||
-        (_currentPlaying != null && _currentPlaying!.isAPlaylist())) {
+        (_currentPlaying != null && await _currentPlaying!.hasNext())) {
       PlayerEngine.playNextSong(nextOnQueue: true);
     } else {
       await PlayerEngine.player.pause();


### PR DESCRIPTION
Previously when a song in a play list with only this song ends, the PlayerEngine enter in an invalid state, now this behaviour is fixed